### PR TITLE
conditional consuming

### DIFF
--- a/workers/compose.yml
+++ b/workers/compose.yml
@@ -8,7 +8,7 @@ services:
   postgres:
     image: postgres
     volumes:
-      - ./init_db/init_postgres.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./init_db/init_postgres.sql.example:/docker-entrypoint-initdb.d/init.sql
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
@@ -48,13 +48,14 @@ services:
     restart: on-failure
     depends_on:
       - rabbitmq
+      - postgres
 
-  consumer:
+  consumer-a:
     build:
       context: ./consumer
     environment:
-      LOG_LEVEL: 20
-      MODEL: casperhansen/mixtral-instruct-awq
+      LOG_LEVEL: 10
+      MODEL: Qwen/Qwen2.5-1.5B-Instruct
       RABBITMQ_USER: guest
       RABBITMQ_PASSWORD: guest
       RABBITMQ_HOST: rabbitmq
@@ -64,22 +65,54 @@ services:
     depends_on:
       - rabbitmq
 
-  vllm:
-    image: vllm/vllm-openai
+  consumer-b:
+    build:
+      context: ./consumer
+    environment:
+      LOG_LEVEL: 10
+      MODEL: Qwen/Qwen2.5-1.5B-Instruct
+      RABBITMQ_USER: guest
+      RABBITMQ_PASSWORD: guest
+      RABBITMQ_HOST: rabbitmq
+      RABBITMQ_PORT: 5672
+      LLM_URL: http://host.docker.internal:50001
+    restart: on-failure
+    depends_on:
+      - rabbitmq
+
+  vllm-a:
+    image: vllm-arm:0.6.6
     ports:
       - 50000:8000
     entrypoint:
       - python3
       - -m
       - vllm.entrypoints.openai.api_server
-      # - --model
-      # - "model"
+      - --model
+      - "Qwen/Qwen2.5-1.5B-Instruct"
       # - --quantization=quantization
-      # - --dtype=dtype
-      # - --gpu-memory-utilization=.gpuMemoryUtilization
-      # - --rope-scaling=rope_scaling_json
-      # - --rope-theta=rope_scaling_theta
+      - --dtype=float16
       - --trust-remote-code
     environment:
-      # - HF_TOKEN=token
-      - PORT=8000
+      - VLLM_PORT=8000
+      - OMP_NUM_THREADS=4  # Limit to 4 CPU threads
+      - VLLM_CPU_MAX_THREADS=4  # (if vLLM respects this env)
+
+  vllm-b:
+    image: vllm-arm:0.6.6
+    ports:
+      - 50001:8001
+    entrypoint:
+      - python3
+      - -m
+      - vllm.entrypoints.openai.api_server
+      - --model
+      - "Qwen/Qwen2.5-1.5B-Instruct"
+      # - --quantization=quantization
+      - --dtype=float16
+      - --trust-remote-code
+      - --port=8001
+    environment:
+      - VLLM_PORT=8001
+      - OMP_NUM_THREADS=4  # Limit to 4 CPU threads
+      - VLLM_CPU_MAX_THREADS=4  # (if vLLM respects this env)

--- a/workers/consumer/metrics.py
+++ b/workers/consumer/metrics.py
@@ -68,12 +68,12 @@ async def wait_for_vllm():
     for i in range(MAX_INITIAL_METRICS_RETRIES):
         try:
             await update_metrics()
-            logging.info("vllm is ready")
+            logging.info("vllm is up")
             break
         except Exception as e:
             logging.error(
-                f"Waiting for vllm to be ready ({i+1}/{MAX_INITIAL_METRICS_RETRIES}): {e}"
+                f"Waiting for vllm to be up ({i+1}/{MAX_INITIAL_METRICS_RETRIES}): {e}"
             )
             await asyncio.sleep(INITIAL_METRCIS_WAIT)
     else:
-        raise Exception(f"vllm is not ready after {INITIAL_METRCIS_WAIT*MAX_INITIAL_METRICS_RETRIES}s")
+        raise Exception(f"vllm is still down after {INITIAL_METRCIS_WAIT*MAX_INITIAL_METRICS_RETRIES}s")


### PR DESCRIPTION
Le consumer check les métriques du serveur d'inférence en continu, et consomme ou non en conséquence. Rend possible le load balancing dans le cas où le même modèle est hébergé sur plusieurs serveurs.  Philosophie à comparer avec #12 