### PR TITLE
monitoring metrics optional

### DIFF
--- a/workers/compose.yml
+++ b/workers/compose.yml
@@ -61,7 +61,7 @@ services:
       RABBITMQ_PASSWORD: guest
       RABBITMQ_HOST: rabbitmq
       RABBITMQ_PORT: 5672
-      VLLM_SERVERS: '{"http://vllm:8000": "optional_token_here"}'
+      VLLM_SERVERS: '{"http://vllm:8000": {"token": "optional_token_here", "exposes_metrics": true}}'
     restart: on-failure
     depends_on:
       - rabbitmq

--- a/workers/consumer/rpc_server.py
+++ b/workers/consumer/rpc_server.py
@@ -25,6 +25,11 @@ NB_USER_THRESHOLD = settings.NB_USER_THRESHOLD
 NB_REQUESTS_IN_QUEUE_THRESHOLD = settings.NB_REQUESTS_IN_QUEUE_THRESHOLD
 
 RPC_RECONNECT_ATTEMPTS = settings.RPC_RECONNECT_ATTEMPTS
+
+VLLM_SERVERS = settings.VLLM_SERVERS
+
+MONITOR_METRICS = settings.MONITOR_METRICS
+
 WAIT_FOR_LLM_DELAY = 1
 
 
@@ -107,7 +112,11 @@ class RPCServer:
 
     async def on_message_callback(self, message: AbstractIncomingMessage):
         logging.debug(f"Message consumed on queue {MODEL}")
-        vllm_server = await self.find_first_available_server(settings.VLLM_SERVERS)
+
+        if MONITOR_METRICS:
+            vllm_server = await self.find_first_available_server(VLLM_SERVERS)
+        else:
+            vllm_server = VLLM_SERVERS[0]
 
         llm_params = {
             'llmUrl': vllm_server.url,

--- a/workers/consumer/settings.py
+++ b/workers/consumer/settings.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     MAX_VLLM_CONNECTION_ATTEMPTS: int = Field(default=100)
     INITIAL_METRCIS_WAIT: int = Field(default=5)
     NB_REQUESTS_IN_QUEUE_THRESHOLD: int = Field(default=5)
+    MONITOR_METRICS: Optional[bool] = Field(default=True)
 
     @property
     def VLLM_SERVERS(self):

--- a/workers/consumer/vllm_server.py
+++ b/workers/consumer/vllm_server.py
@@ -4,3 +4,4 @@ from dataclasses import dataclass
 class VLLMServer:
     url: str
     token: str
+    exposes_metrics: bool


### PR DESCRIPTION
Permettre de traiter les requêtes sans vérifier au préalable la disponibilité des serveurs (utile si le serveur cible n'a pas de endpoint de métrique qui convient)