### PR TITLE
routing strategy

### DIFF
--- a/workers/compose.yml
+++ b/workers/compose.yml
@@ -55,6 +55,7 @@ services:
       LOG_LEVEL: 10
       MODEL: Qwen/Qwen2.5-1.5B-Instruct
       VLLM_SERVERS: '{"http://vllm:8000": "optional_token_here"}'
+      ROUTING_STRATEGY: less-busy
     restart: on-failure
     depends_on:
       - rabbitmq

--- a/workers/consumer/exceptions.py
+++ b/workers/consumer/exceptions.py
@@ -14,3 +14,9 @@ class NoSuitableVllm(Exception):
     def __init__(self):
         message = "No suitable VLLM server found with good enough metrics"
         super().__init__(message)
+
+
+class UnknownStrategy(Exception):
+    def __init__(self, passed_strategy):
+        message = f'"{passed_strategy}" not recognized; strategy must be either round-robin or less-busy'
+        super().__init__(message)

--- a/workers/consumer/rpc_server.py
+++ b/workers/consumer/rpc_server.py
@@ -25,6 +25,14 @@ AVG_TOKEN_THRESHOLD = settings.AVG_TOKEN_THRESHOLD
 NB_USER_THRESHOLD = settings.NB_USER_THRESHOLD
 NB_REQUESTS_IN_QUEUE_THRESHOLD = settings.NB_REQUESTS_IN_QUEUE_THRESHOLD
 
+RPC_RECONNECT_ATTEMPTS = settings.RPC_RECONNECT_ATTEMPTS
+WAIT_FOR_LLM_DELAY = 1
+
+VLLM_SERVERS = settings.VLLM_SERVERS
+
+ROUTING_STRATEGY = settings.ROUTING_STRATEGY
+LESS_BUSY = "less-busy"
+ROUND_ROBIN = "round-robin"
 
 class RPCServer:
     def __init__(self, url: str) -> None:
@@ -32,6 +40,7 @@ class RPCServer:
         self.connection: AbstractConnection = None
         self.channel: AbstractChannel = None
         self.queue: AbstractQueue = None
+        self.round_robin_idx = 0
 
     async def first_connect(self) -> None:
         logging.debug("Connecting consumer to RabbitMQ...")
@@ -110,10 +119,18 @@ class RPCServer:
 
     async def on_message_callback(self, message: AbstractIncomingMessage):
         logging.debug("Message consumed on queue %s", MODEL)
-        vllm_server = await self.find_first_available_server(settings.VLLM_SERVERS)
-
-        llm_params = {"llmUrl": vllm_server.url, "llmToken": vllm_server.token}
-
+        
+        if ROUTING_STRATEGY == LESS_BUSY:
+            vllm_server = await self.find_first_available_server(VLLM_SERVERS)
+        elif ROUTING_STRATEGY == ROUND_ROBIN: # elif for clarity but it's really an else, since ROUTING_STRATEGY is enforced to be either LESS_BUSY or ROUND_ROBIN
+            vllm_server = VLLM_SERVERS[self.round_robin_idx]
+            self.round_robin_idx = (self.round_robin_idx + 1) % len(VLLM_SERVERS)
+        
+        llm_params = {
+            'llmUrl': vllm_server.url,
+            'llmToken': vllm_server.token
+        }
+        
         try:
             await self.channel.default_exchange.publish(
                 Message(

--- a/workers/consumer/settings.py
+++ b/workers/consumer/settings.py
@@ -1,10 +1,6 @@
-from typing import Optional, Literal
-from pydantic_settings import BaseSettings
-from pydantic import Field
-from vllm_server import VLLMServer
-import logging
 import json
 import logging
+from typing import Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings

--- a/workers/consumer/settings.py
+++ b/workers/consumer/settings.py
@@ -1,3 +1,8 @@
+from typing import Optional, Literal
+from pydantic_settings import BaseSettings
+from pydantic import Field
+from vllm_server import VLLMServer
+import logging
 import json
 import logging
 
@@ -23,6 +28,7 @@ class Settings(BaseSettings):
     MAX_VLLM_CONNECTION_ATTEMPTS: int = Field(default=100)
     INITIAL_METRCIS_WAIT: int = Field(default=5)
     NB_REQUESTS_IN_QUEUE_THRESHOLD: int = Field(default=5)
+    ROUTING_STRATEGY: Literal["less-busy", "round-robin"] = Field(default=None)
 
     @property
     def VLLM_SERVERS(self):  # pylint: disable=invalid-name


### PR DESCRIPTION
Permet de choisir entre les stratégies less busy (regarder les métriques et fw la requête au premier serveur qui répond avec des métriques satisfaisantes) et round robin (dispatcher les requêtes équitablement entre les serveurs hébergeant le même modèle, sans regarder les métriques au préalable).