### PR TITLE
Vllm >= v0.7

### DIFF
--- a/workers/compose.yml
+++ b/workers/compose.yml
@@ -55,7 +55,7 @@ services:
       LOG_LEVEL: 10
       MODEL: Qwen/Qwen2.5-1.5B-Instruct
       VLLM_SERVERS: '{"http://vllm:8000": "optional_token_here"}'
-      ROUTING_STRATEGY: less-busy
+      ROUTING_STRATEGY: least_busy
     restart: on-failure
     depends_on:
       - rabbitmq

--- a/workers/compose.yml
+++ b/workers/compose.yml
@@ -55,7 +55,8 @@ services:
       LOG_LEVEL: 10
       MODEL: Qwen/Qwen2.5-1.5B-Instruct
       VLLM_SERVERS: '{"http://vllm:8000": "optional_token_here"}'
-      ROUTING_STRATEGY: least_busy
+      ROUTING_STRATEGY: least-busy
+      TIME_TO_FIRST_TOKEN_THRESHOLD: 1.0
     restart: on-failure
     depends_on:
       - rabbitmq

--- a/workers/consumer/exceptions.py
+++ b/workers/consumer/exceptions.py
@@ -18,5 +18,13 @@ class NoSuitableVllm(Exception):
 
 class UnknownStrategy(Exception):
     def __init__(self, passed_strategy):
-        message = f'"{passed_strategy}" not recognized; strategy must be either round-robin or least_busy'
+        message = f'"{passed_strategy}" not recognized; strategy must be either round-robin or least-busy'
+        super().__init__(message)
+
+
+class PercentileComputationError(Exception):
+    def __init__(self, percentile, histogram):
+        message = (
+            f"Couldn't find {100*percentile}th percentile for histogram: {histogram}"
+        )
         super().__init__(message)

--- a/workers/consumer/exceptions.py
+++ b/workers/consumer/exceptions.py
@@ -18,5 +18,5 @@ class NoSuitableVllm(Exception):
 
 class UnknownStrategy(Exception):
     def __init__(self, passed_strategy):
-        message = f'"{passed_strategy}" not recognized; strategy must be either round-robin or less-busy'
+        message = f'"{passed_strategy}" not recognized; strategy must be either round-robin or least_busy'
         super().__init__(message)

--- a/workers/consumer/main.py
+++ b/workers/consumer/main.py
@@ -17,6 +17,7 @@ RABBITMQ_URL = settings.RABBITMQ_URL
 ROUTING_STRATEGY = settings.ROUTING_STRATEGY
 LEAST_BUSY = "least-busy"
 ROUND_ROBIN = "round-robin"
+TIME_TO_FIRST_TOKEN_THRESHOLD = settings.TIME_TO_FIRST_TOKEN_THRESHOLD
 
 shutdown_signal = asyncio.Event()
 
@@ -45,7 +46,7 @@ if __name__ == "__main__":
     logging.info("Starting consumer")
 
     if ROUTING_STRATEGY == LEAST_BUSY:
-        strategy = LeastBusy(VLLM_SERVERS)
+        strategy = LeastBusy(VLLM_SERVERS, TIME_TO_FIRST_TOKEN_THRESHOLD)
     elif ROUTING_STRATEGY == ROUND_ROBIN:
         strategy = RoundRobin(VLLM_SERVERS)
     else:

--- a/workers/consumer/main.py
+++ b/workers/consumer/main.py
@@ -2,25 +2,38 @@ import asyncio
 import logging
 import signal
 
+from .exceptions import UnknownStrategy
 from .metrics import wait_for_vllms
-from .probes import prober
-from .rpc_server import rpc_server
+from .probes import Prober
+from .rpc_server import RPCServer
 from .settings import settings
+from .strategy.least_busy import LeastBusy
+from .strategy.round_robin import RoundRobin
+from .strategy.server_selection_strategy import ServerSelectionStrategy
+
+VLLM_SERVERS = settings.VLLM_SERVERS
+RABBITMQ_URL = settings.RABBITMQ_URL
+
+ROUTING_STRATEGY = settings.ROUTING_STRATEGY
+LEAST_BUSY = "least-busy"
+ROUND_ROBIN = "round-robin"
 
 shutdown_signal = asyncio.Event()
 
 
-async def main_consumer():
-    await wait_for_vllms(settings.VLLM_SERVERS)
+async def main_consumer(p_strategy: ServerSelectionStrategy, p_rpc_server: RPCServer):
+    await wait_for_vllms(VLLM_SERVERS)
 
-    await rpc_server.first_connect()
+    await p_strategy.monitor()
+    await p_rpc_server.first_connect()
 
     # Consumer is running until shutdown signal is received
     # Until then, all action occurs in the on_message_callback
     # of the RPCServer class
     await shutdown_signal.wait()
 
-    await rpc_server.close()
+    await p_rpc_server.close()
+    await p_strategy.stop_monitor()
 
 
 def shutdown():
@@ -30,6 +43,17 @@ def shutdown():
 
 if __name__ == "__main__":
     logging.info("Starting consumer")
+
+    if ROUTING_STRATEGY == LEAST_BUSY:
+        strategy = LeastBusy(VLLM_SERVERS)
+    elif ROUTING_STRATEGY == ROUND_ROBIN:
+        strategy = RoundRobin(VLLM_SERVERS)
+    else:
+        raise UnknownStrategy(ROUTING_STRATEGY)
+
+    rpc_server = RPCServer(RABBITMQ_URL, strategy)
+
+    prober = Prober(rpc_server)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -41,7 +65,7 @@ if __name__ == "__main__":
         loop.run_until_complete(prober.setup())
 
     try:
-        loop.run_until_complete(main_consumer())
+        loop.run_until_complete(main_consumer(strategy, rpc_server))
     except Exception as e:
         logging.fatal("Consumer fatal error: %s", e)
         raise

--- a/workers/consumer/metrics.py
+++ b/workers/consumer/metrics.py
@@ -1,9 +1,6 @@
 import asyncio
 import logging
-import re
-from math import inf
-from time import time
-from typing import List, Tuple
+from typing import List
 
 from httpx import AsyncClient
 
@@ -23,106 +20,6 @@ async def ping_server(vllm_server: VLLMServer) -> None:
     async with AsyncClient(base_url=vllm_server.url) as http_client:
         response = await http_client.get("/metrics/")
         response.raise_for_status()
-
-
-def tokens_per_s(
-    tokens_total: float,
-    last_generation_tokens_total: float,
-    timestamp: float,
-    last_update_timestamp: float,
-) -> float:
-    time_diff = timestamp - last_update_timestamp
-    token_diff = tokens_total - last_generation_tokens_total
-    if token_diff > 0:
-        return token_diff / time_diff
-    return 0.0
-
-
-def update_throughput(
-    content: str, pattern: str, vllm_server: VLLMServer, throughput_metrics: dict
-) -> float:
-    timestamp = time()
-    tokens_total = float(
-        re.search(pattern, content, re.MULTILINE).group(0).split(" ")[1]
-    )
-
-    if throughput_metrics[vllm_server.url]["first_update"]:
-        tokens_per_second = 0.0
-        throughput_metrics[vllm_server.url]["first_update"] = False
-    else:
-        last_timestamp = throughput_metrics[vllm_server.url]["last_update_timestamp"]
-        last_tokens_total = throughput_metrics[vllm_server.url][
-            "last_generation_tokens_total"
-        ]
-        tokens_per_second = tokens_per_s(
-            tokens_total, last_tokens_total, timestamp, last_timestamp
-        )
-
-    throughput_metrics[vllm_server.url]["last_generation_tokens_total"] = tokens_total
-    throughput_metrics[vllm_server.url]["last_update_timestamp"] = timestamp
-
-    return tokens_per_second
-
-
-async def update_metrics(
-    vllm_server: VLLMServer, throughput_metrics: dict
-) -> Tuple[float, float, float, VLLMServer]:
-
-    async with AsyncClient(base_url=vllm_server.url) as http_client:
-        response = await http_client.get("/metrics/")
-        response.raise_for_status()
-
-    content = response.text
-
-    generation_tokens_total = r"^vllm:generation_tokens_total.*$"
-    throughput = r"^vllm:avg_generation_throughput_toks_per_s.*$"
-    num_requests_running = r"^vllm:num_requests_running.*$"
-    num_requests_waiting = r"^vllm:num_requests_waiting.*$"
-
-    current_nb_users = float(
-        re.search(num_requests_running, content, re.MULTILINE).group(0).split(" ")[1]
-    )
-    current_nb_requests_in_queue = float(
-        re.search(num_requests_waiting, content, re.MULTILINE).group(0).split(" ")[1]
-    )
-
-    version_sub_0_7 = re.search(throughput, content, re.MULTILINE)
-    # vllm versions < 0.7 expose the throughput metric. If it's there, we use it
-    if version_sub_0_7:
-        tokens_per_second = version_sub_0_7.group(0).split(" ")[1]
-    # otherwise we compute it by hand based on total tokens and time elapsed
-    else:
-        tokens_per_second = update_throughput(
-            content, generation_tokens_total, vllm_server, throughput_metrics
-        )
-
-    current_avg_token = (
-        tokens_per_second / current_nb_users if current_nb_users else inf
-    )
-
-    logging.debug(
-        " > [Metrics for %s] Tokens per second: %s", vllm_server.url, tokens_per_second
-    )
-    logging.debug(
-        " > [Metrics for %s] Running requests: %s", vllm_server.url, current_nb_users
-    )
-    logging.debug(
-        " > [Metrics for %s] Waiting requests: %s",
-        vllm_server.url,
-        current_nb_requests_in_queue,
-    )
-    logging.debug(
-        " > [Metrics for %s] Average token per user: %s",
-        vllm_server.url,
-        current_avg_token,
-    )
-
-    return (
-        current_avg_token,
-        current_nb_users,
-        current_nb_requests_in_queue,
-        vllm_server,
-    )
 
 
 async def wait_for_vllms(vllm_servers: List[VLLMServer]) -> None:

--- a/workers/consumer/probes.py
+++ b/workers/consumer/probes.py
@@ -1,12 +1,13 @@
 from aiohttp import web
 
-from .rpc_server import rpc_server
+from .rpc_server import RPCServer
 from .settings import settings
 
 
 class Prober:
-    def __init__(self):
+    def __init__(self, rpc_server: RPCServer):
         self.app = web.Application()
+        self.rpc_server = rpc_server
         self.app.router.add_get("/health", self.handle_health_check)
         self.app.router.add_get("/ready", self.handle_ready_check)
         self.runner = web.AppRunner(self.app)
@@ -28,9 +29,6 @@ class Prober:
 
     async def handle_ready_check(self):
         # Consumer is ready when it is connected to RabbitMQ
-        if rpc_server.check_connection():
+        if self.rpc_server.check_connection():
             return web.Response(text="OK", status=200)
         return web.Response(text="NOK", status=503)
-
-
-prober = Prober()

--- a/workers/consumer/rpc_server.py
+++ b/workers/consumer/rpc_server.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from time import time
 
 from aio_pika import DeliveryMode, Message, connect_robust
 from aio_pika.abc import (
@@ -47,7 +46,7 @@ class RPCServer:
             vllm.url: {
                 "last_generation_tokens_total": None,
                 "last_update_timestamp": None,
-                "first_update": True
+                "first_update": True,
             }
             for vllm in self.vllm_servers
         }

--- a/workers/consumer/rpc_server.py
+++ b/workers/consumer/rpc_server.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import List
+from time import time
 
 from aio_pika import DeliveryMode, Message, connect_robust
 from aio_pika.abc import (
@@ -42,6 +42,15 @@ class RPCServer:
         self.channel: AbstractChannel = None
         self.queue: AbstractQueue = None
         self.round_robin_idx = 0
+        self.vllm_servers = settings.VLLM_SERVERS
+        self.throughput_metrics = {
+            vllm.url: {
+                "last_generation_tokens_total": None,
+                "last_update_timestamp": None,
+                "first_update": True
+            }
+            for vllm in self.vllm_servers
+        }
 
     async def first_connect(self) -> None:
         logging.debug("Connecting consumer to RabbitMQ...")
@@ -98,7 +107,7 @@ class RPCServer:
                 logging.info("RPC disconnected")
 
     async def find_first_available_server(
-        self, vllm_servers: List[VLLMServer], retry: int = DEFAULT_RETRY
+        self, retry: int = DEFAULT_RETRY
     ) -> VLLMServer:
         async for (
             current_avg_token,
@@ -106,7 +115,7 @@ class RPCServer:
             current_nb_requests_in_queue,
             vllm_server,
             tasks,
-        ) in stream_update_metrics(vllm_servers, retry):
+        ) in stream_update_metrics(self.vllm_servers, self.throughput_metrics, retry):
             if current_nb_requests_in_queue <= NB_REQUESTS_IN_QUEUE_THRESHOLD and (
                 current_avg_token >= AVG_TOKEN_THRESHOLD
                 or current_nb_users <= NB_USER_THRESHOLD

--- a/workers/consumer/settings.py
+++ b/workers/consumer/settings.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     MAX_VLLM_CONNECTION_ATTEMPTS: int = Field(default=100)
     INITIAL_METRCIS_WAIT: int = Field(default=5)
     NB_REQUESTS_IN_QUEUE_THRESHOLD: int = Field(default=5)
-    ROUTING_STRATEGY: Literal["least_busy", "round-robin"] = Field(default=None)
+    ROUTING_STRATEGY: Literal["least-busy", "round-robin"] = Field(default=None)
 
     @property
     def VLLM_SERVERS(self):  # pylint: disable=invalid-name

--- a/workers/consumer/settings.py
+++ b/workers/consumer/settings.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     MAX_VLLM_CONNECTION_ATTEMPTS: int = Field(default=100)
     INITIAL_METRCIS_WAIT: int = Field(default=5)
     NB_REQUESTS_IN_QUEUE_THRESHOLD: int = Field(default=5)
-    ROUTING_STRATEGY: Literal["less-busy", "round-robin"] = Field(default=None)
+    ROUTING_STRATEGY: Literal["least_busy", "round-robin"] = Field(default=None)
 
     @property
     def VLLM_SERVERS(self):  # pylint: disable=invalid-name

--- a/workers/consumer/strategy/histogram.py
+++ b/workers/consumer/strategy/histogram.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import re
+from math import inf
+
 
 class Histogram(dict[float, float]):
     """Represents a latency histogram mapping latency thresholds to counts."""
+
+    bucket_pattern = r'le="([\d+.inf]+)".*? (\d+\.\d+)'
 
     def __sub__(self, other: Histogram) -> Histogram:
         """Returns a histogram representing the difference between two histograms."""
@@ -16,3 +21,23 @@ class Histogram(dict[float, float]):
     def diff(self, other: Histogram) -> Histogram:
         """Alias for subtraction for semantic clarity."""
         return self - other
+
+    @staticmethod
+    def parse(content: str, pattern: str) -> Histogram:
+        matches = re.findall(pattern, content, re.MULTILINE)
+        histogram = Histogram()
+
+        # when no request have ever been recorded, vllm does not expose empty histograms
+        # so matches can be None
+        if matches:
+            for line in matches[:-1]:
+                match = re.search(Histogram.bucket_pattern, line, re.IGNORECASE)
+                if match:
+                    histogram[float(match.group(1))] = float(match.group(2))
+
+            # last bucket is treated separately because of key '+Inf' instead of number
+            match = re.search(Histogram.bucket_pattern, matches[-1], re.IGNORECASE)
+            if match:
+                histogram[inf] = float(match.group(2))
+
+        return histogram

--- a/workers/consumer/strategy/histogram.py
+++ b/workers/consumer/strategy/histogram.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+
+class Histogram(dict[float, float]):
+    """Represents a latency histogram mapping latency thresholds to counts."""
+
+    def __sub__(self, other: Histogram) -> Histogram:
+        """Returns a histogram representing the difference between two histograms."""
+        return Histogram(
+            {
+                key: self.get(key, 0) - other.get(key, 0)
+                for key in set(self.keys()) | set(other.keys())
+            }
+        )
+
+    def diff(self, other: Histogram) -> Histogram:
+        """Alias for subtraction for semantic clarity."""
+        return self - other

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -10,55 +10,55 @@ from ..vllm_server import VLLMServer
 from .server_selection_strategy import ServerSelectionStrategy
 
 
-def get_percentile(histogram: dict, percentile: float = 0.95) -> tuple[int, float]:
-    """
-    histogram has the following shape:
-    {
-        0.3: 0.0,
-        0.5: 1.0,
-        0.8: 4.0,
-        ...
-        inf: <total number of requests>
-    }
-
-    sorted_buckets then has the following shape:
-    [
-        (0.3, 0.0), (0.5, 1.0), (0.8, 4.0), ...
-    ]
-    """
-    sorted_buckets = sorted(histogram.items())
-    total_requests = sorted_buckets[-1][1]
-    percentile_count = percentile * total_requests
-    for i, (bucket, count) in enumerate(sorted_buckets):
-        if count >= percentile_count:
-            return (i, bucket)
-    return None
-    # Should never be reached, since count holds total_requests during last iteration,
-    # which will always be bigger than percentile*total_requests for percentile<1
-
-
-def business_score(
-    e2e_bucket: tuple[int, float], tft_bucket: tuple[int, float]
-) -> float:
-    """
-    both buckets have the shape (bucket_index, bucket_value)
-    as returned by the get_percentile function
-    """
-    # TODO: define a score based on e2e time and time to first token time
-    return 0.0
-
-
-def least_busy(scores: dict) -> str:
-    """
-    scores is a dict of shape {url: score} for each server
-    """
-    return min(scores, key=lambda x: scores[x])
-
-
 class LeastBusy(ServerSelectionStrategy):
     e2e_latency_pattern = r"^vllm:e2e_request_latency_seconds_bucket.*$"
     time_to_first_token_pattern = r"^vllm:time_to_first_token_seconds_bucket.*$"
     bucket_pattern = r'le="([\d+.inf]+)".*? (\d+\.\d+)'
+
+    @staticmethod
+    def get_percentile(histogram: dict, percentile: float = 0.95) -> tuple[int, float]:
+        """
+        histogram has the following shape:
+        {
+            0.3: 0.0,
+            0.5: 1.0,
+            0.8: 4.0,
+            ...
+            inf: <total number of requests>
+        }
+
+        sorted_buckets then has the following shape:
+        [
+            (0.3, 0.0), (0.5, 1.0), (0.8, 4.0), ...
+        ]
+        """
+        sorted_buckets = sorted(histogram.items())
+        total_requests = sorted_buckets[-1][1]
+        percentile_count = percentile * total_requests
+        for i, (bucket, count) in enumerate(sorted_buckets):
+            if count >= percentile_count:
+                return (i, bucket)
+        return None
+        # Should never be reached, since count holds total_requests during last iteration,
+        # which will always be bigger than percentile*total_requests for percentile<1
+
+    @staticmethod
+    def business_score(
+        e2e_bucket: tuple[int, float], tft_bucket: tuple[int, float]
+    ) -> float:
+        """
+        both buckets have the shape (bucket_index, bucket_value)
+        as returned by the get_percentile function
+        """
+        # TODO: define a score based on e2e time and time to first token time
+        return 0.0
+
+    @staticmethod
+    def least_busy(scores: dict) -> str:
+        """
+        scores is a dict of shape {url: score} for each server
+        """
+        return min(scores, key=lambda x: scores[x])
 
     def __init__(self, servers: List[VLLMServer]) -> None:
         super().__init__(servers)
@@ -72,7 +72,8 @@ class LeastBusy(ServerSelectionStrategy):
         self.monitoring = False
         self._monitor_tasks = []
 
-    async def fetch_metrics(self, session: aiohttp.ClientSession, url: str) -> str:
+    @staticmethod
+    async def fetch_metrics(session: aiohttp.ClientSession, url: str) -> str:
         async with session.get(f"{url}/metrics") as response:
             response.raise_for_status()
             return await response.text()
@@ -82,19 +83,20 @@ class LeastBusy(ServerSelectionStrategy):
         histogram = {}
 
         for line in matches[:-1]:
-            match = re.search(self.bucket_pattern, line, re.IGNORECASE)
+            match = re.search(LeastBusy.bucket_pattern, line, re.IGNORECASE)
             if match:
                 histogram[float(match.group(1))] = float(match.group(2))
 
         # last bucket is treated separately because of key '+Inf' instead of number
-        match = re.search(self.bucket_pattern, matches[-1], re.IGNORECASE)
+        match = re.search(LeastBusy.bucket_pattern, matches[-1], re.IGNORECASE)
         if match:
             histogram[inf] = float(match.group(2))
 
         return histogram
 
+    @staticmethod
     def update_histogram(
-        self, new_histogram: dict, last_histogram: dict, diff_histogram: dict
+        new_histogram: dict, last_histogram: dict, diff_histogram: dict
     ):
         new_diff_histogram = {}
         if last_histogram:
@@ -110,25 +112,25 @@ class LeastBusy(ServerSelectionStrategy):
         self, session: aiohttp.ClientSession, url: str
     ) -> None:
         """Fetch metrics once and update histograms for different patterns."""
-        content = await self.fetch_metrics(session, url)
+        content = await LeastBusy.fetch_metrics(session, url)
         if not content:
             return
 
         # Process histograms for different patterns
         for pattern, last_histograms, diff_histograms in [
             (
-                self.e2e_latency_pattern,
+                LeastBusy.e2e_latency_pattern,
                 self.e2e_latency_last_histograms,
                 self.e2e_latency_diff_histograms,
             ),
             (
-                self.time_to_first_token_pattern,
+                LeastBusy.time_to_first_token_pattern,
                 self.time_to_first_token_last_histograms,
                 self.time_to_first_token_diff_histograms,
             ),
         ]:
             new_histogram = self.parse_histogram(content, pattern)
-            self.update_histogram(
+            LeastBusy.update_histogram(
                 new_histogram,
                 last_histograms.setdefault(url, {}),
                 diff_histograms.setdefault(url, {}),
@@ -181,11 +183,11 @@ class LeastBusy(ServerSelectionStrategy):
         scores = {}
         for url in self.urls:
             e2e_histogram = self.e2e_latency_diff_histograms[url]
-            e2e_bucket_95 = get_percentile(e2e_histogram)
+            e2e_bucket_95 = LeastBusy.get_percentile(e2e_histogram)
             tft_histogram = self.time_to_first_token_diff_histograms[url]
-            tft_bucket_95 = get_percentile(tft_histogram)
-            scores[url] = business_score(e2e_bucket_95, tft_bucket_95)
-        url_least_busy = least_busy(scores)
+            tft_bucket_95 = LeastBusy.get_percentile(tft_histogram)
+            scores[url] = LeastBusy.business_score(e2e_bucket_95, tft_bucket_95)
+        url_least_busy = LeastBusy.least_busy(scores)
         # Only at choose time, we find back the server object corresponding to the chosen url,
         # because that's what the abstract class declared (more straightforward for the consumer)
         for server in self.servers:

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -1,0 +1,169 @@
+import asyncio
+import re
+from math import inf
+from typing import List
+
+import aiohttp
+
+from ..vllm_server import VLLMServer
+from .server_selection_strategy import ServerSelectionStrategy
+
+
+def get_percentile(histogram: dict, percentile: float = 0.95) -> tuple[int, float]:
+    """
+    histogram has the following shape:
+    {
+        0.3: 0.0,
+        0.5: 1.0,
+        0.8: 4.0,
+        ...
+        inf: <total number of requests>
+    }
+
+    sorted_buckets then has the following shape:
+    [
+        (0.3, 0.0), (0.5, 1.0), (0.8, 4.0), ...
+    ]
+    """
+    sorted_buckets = sorted(histogram.items())
+    total_requests = sorted_buckets[-1][1]
+    percentile_count = percentile * total_requests
+    for i, (bucket, count) in enumerate(sorted_buckets):
+        if count >= percentile_count:
+            return (i, bucket)
+    return None
+    # Should never be reached, since count holds total_requests during last iteration,
+    # which will always be bigger than percentile*total_requests for percentile<1
+
+
+def business_score(
+    e2e_bucket: tuple[int, float], tft_bucket: tuple[int, float]
+) -> float:
+    """
+    both buckets have the shape (bucket_index, bucket_value)
+    as returned by the get_percentile function
+    """
+    # TODO: define a score based on e2e time and time to first token time
+    return 0.0
+
+
+def least_busy(scores: dict) -> str:
+    """
+    scores is a dict of shape {url: score} for each server
+    """
+    return min(scores, key=lambda x: scores[x])
+
+
+class LeastBusy(ServerSelectionStrategy):
+    e2e_latency_pattern = r"^vllm:e2e_request_latency_seconds_bucket.*$"
+    time_to_first_token_pattern = r"^vllm:time_to_first_token_seconds_bucket.*$"
+    bucket_pattern = r'le="([\d+.inf]+)".*? (\d+\.\d+)'
+
+    def __init__(self, servers: List[VLLMServer]) -> None:
+        super().__init__(servers)
+        self.urls = [server.url for server in servers]
+        # The whole monitoring process only cares about urls, not complete server object,
+        # which are less handy to use as dictionnary keys (i.e to hash)
+        self.e2e_latency_last_histograms = {url: {} for url in self.urls}
+        self.e2e_latency_diff_histograms = {url: {} for url in self.urls}
+        self.time_to_first_token_last_histograms = {url: {} for url in self.urls}
+        self.time_to_first_token_diff_histograms = {url: {} for url in self.urls}
+        self.monitoring = False
+
+        asyncio.run(self.monitor())
+
+    async def update_histogram(
+        self, session: aiohttp.ClientSession, url: str, pattern: str
+    ) -> None:
+        try:
+            async with session.get(url) as response:
+                content = await response.text()
+
+            # all 'bucket' lines
+            res = re.findall(pattern, content, re.MULTILINE)
+            new_histogram = {}
+
+            for line in res[:-1]:
+                match = re.search(self.bucket_pattern, line, re.IGNORECASE)
+                if match:
+                    new_histogram[float(match.group(1))] = float(match.group(2))
+
+            # last bucket is treated separately because of key '+Inf' instead of number
+            match = re.search(self.bucket_pattern, res[-1], re.IGNORECASE)
+            if match:
+                new_histogram[inf] = float(match.group(2))
+
+            if pattern == self.e2e_latency_pattern:
+                last_histogram = self.e2e_latency_last_histograms[url]
+                diff_histogram = self.e2e_latency_diff_histograms[url]
+            else:
+                last_histogram = self.time_to_first_token_last_histograms[url]
+                diff_histogram = self.time_to_first_token_diff_histograms[url]
+
+            new_diff_histogram = {}
+            if last_histogram:
+                for key in last_histogram:
+                    new_diff_histogram[key] = new_histogram.get(
+                        key, 0
+                    ) - last_histogram.get(key, 0)
+
+            last_histogram.update(new_histogram)
+            diff_histogram.update(new_diff_histogram)
+
+        except Exception as e:
+            print(f"Error updating metrics from {url}: {str(e)}")
+
+    async def update_all_metrics_for_server(
+        self, session: aiohttp.ClientSession, url: str
+    ) -> None:
+        await asyncio.gather(
+            self.update_histogram(session, url, self.e2e_latency_pattern),
+            self.update_histogram(session, url, self.time_to_first_token_pattern),
+        )
+
+    async def _monitor_server(self, url: str, interval: int) -> None:
+        async with aiohttp.ClientSession() as session:
+            while self.monitoring:
+                await self.update_all_metrics_for_server(session, url)
+                print(f"Metrics updated for {url}")
+                print(f"e2e latency histogram: {self.e2e_latency_diff_histograms[url]}")
+                print(
+                    f"time-to-first-token histogram: {self.time_to_first_token_diff_histograms[url]}"
+                )
+                await asyncio.sleep(interval)
+
+    async def monitor(self, interval: int = 10) -> None:
+        if self.monitoring:
+            print("Monitoring is already running.")
+            return
+
+        self.monitoring = True
+        tasks = [self._monitor_server(url, interval) for url in self.urls]
+        print(f"Started monitoring for {len(self.urls)} servers")
+        await asyncio.gather(*tasks)
+
+    def stop_monitor(self) -> None:
+        if not self.monitoring:
+            print("Monitoring is not running.")
+            return
+
+        self.monitoring = False
+        print("Monitoring stopped for all servers.")
+
+    def choose_server(self) -> VLLMServer:
+        scores = {}
+        for url in self.urls:
+            e2e_histogram = self.e2e_latency_diff_histograms[url]
+            e2e_bucket_95 = get_percentile(e2e_histogram)
+            tft_histogram = self.time_to_first_token_diff_histograms[url]
+            tft_bucket_95 = get_percentile(tft_histogram)
+            scores[url] = business_score(e2e_bucket_95, tft_bucket_95)
+        url_least_busy = least_busy(scores)
+        # Only at choose time, we find back the server object corresponding to the chosen url,
+        # because that's what the abstract class declared (more straightforward for the consumer)
+        for server in self.servers:
+            if server.url == url_least_busy:
+                return server
+        return None
+        # Shouldn't happen since url_least_busy is one of self.urls,
+        # which itself is built from self.servers

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -76,9 +76,11 @@ class LeastBusy(MetricsBasedStrategy):
         """
         scores is a dict of shape {url: score} for each server
         """
-        candidates = [url for url, score in scores.items() if score < threshold]
-        if not candidates:
+        filtered = {k: v for k, v in scores.items() if v <= threshold}
+        if not filtered:
             return ""
+        min_value = min(filtered.values())
+        candidates = [k for k, v in filtered.items() if v == min_value]
         return random.choice(candidates)
 
     def choose_server(self) -> VLLMServer:

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -62,7 +62,6 @@ class LeastBusy(MetricsBasedStrategy):
 
     @staticmethod
     def business_score(
-        e2e_bucket: tuple[int, float],  # pylint: disable=unused-argument
         tft_bucket: tuple[int, float],
     ) -> float:
         """
@@ -86,11 +85,9 @@ class LeastBusy(MetricsBasedStrategy):
         scores = {}
         url_least_busy = None
         for url in self.tracker.urls:
-            e2e_histogram = self.tracker.e2e_latency_diff_histograms[url]
-            e2e_bucket_95 = LeastBusy.get_percentile(e2e_histogram)
             tft_histogram = self.tracker.time_to_first_token_diff_histograms[url]
             tft_bucket_95 = LeastBusy.get_percentile(tft_histogram)
-            scores[url] = LeastBusy.business_score(e2e_bucket_95, tft_bucket_95)
+            scores[url] = LeastBusy.business_score(tft_bucket_95)
             if scores[url] == -1:
                 url_least_busy = url
         # edge case: when a server has never received any request,

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 from typing import List
 
-from ..exceptions import NoSuitableVllm
+from ..exceptions import NoSuitableVllm, PercentileComputationError
 from ..vllm_server import VLLMServer
 from .metrics_based_strategy import MetricsBasedStrategy
 from .metrics_tracker import MetricsTracker
@@ -56,9 +56,7 @@ class LeastBusy(MetricsBasedStrategy):
         for i, (bucket, count) in enumerate(sorted_buckets):
             if count >= percentile_count:
                 return (i, bucket)
-        raise Exception(
-            f"Couldn't find {100*percentile}th percentile for histogram: {histogram}"
-        )
+        raise PercentileComputationError(percentile, histogram)
         # Should never be reached, since count holds total_requests during last iteration,
         # which will always be bigger than percentile*total_requests for percentile<1
 

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -98,13 +98,7 @@ class LeastBusy(MetricsBasedStrategy):
         # but then it needs a request for us to start effectively monitoring, so we prioritize it
         if not url_least_busy:
             url_least_busy = LeastBusy.least_busy(scores, self.threshold)
-        # Only at choose time, we find back the server object corresponding to the chosen url,
-        # because that's what the abstract class declared (more straightforward for the consumer)
         for server in self.servers:
             if server.url == url_least_busy:
                 return server
         raise NoSuitableVllm()
-        # Can only happen when least_busy returns an empty string,
-        # which happens when no suitable server has been found.
-        # Otherwise, url_least_busy is one of self.urls,
-        # which itself is built from self.servers

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -56,7 +56,7 @@ class LeastBusy(MetricsBasedStrategy):
         for i, (bucket, count) in enumerate(sorted_buckets):
             if count >= percentile_count:
                 return (i, bucket)
-        return None
+        raise Exception(f"Couldn't find {100*percentile}th percentile for histogram: {histogram}")
         # Should never be reached, since count holds total_requests during last iteration,
         # which will always be bigger than percentile*total_requests for percentile<1
 

--- a/workers/consumer/strategy/least_busy.py
+++ b/workers/consumer/strategy/least_busy.py
@@ -56,7 +56,9 @@ class LeastBusy(MetricsBasedStrategy):
         for i, (bucket, count) in enumerate(sorted_buckets):
             if count >= percentile_count:
                 return (i, bucket)
-        raise Exception(f"Couldn't find {100*percentile}th percentile for histogram: {histogram}")
+        raise Exception(
+            f"Couldn't find {100*percentile}th percentile for histogram: {histogram}"
+        )
         # Should never be reached, since count holds total_requests during last iteration,
         # which will always be bigger than percentile*total_requests for percentile<1
 

--- a/workers/consumer/strategy/metrics_based_strategy.py
+++ b/workers/consumer/strategy/metrics_based_strategy.py
@@ -1,0 +1,32 @@
+from abc import abstractmethod
+from typing import List
+
+from ..vllm_server import VLLMServer
+from .metrics_tracker import MetricsTracker
+from .server_selection_strategy import ServerSelectionStrategy
+
+
+class MetricsBasedStrategy(ServerSelectionStrategy):
+    """
+    Strategy interface for strategies that depend on server metrics.
+    """
+
+    def __init__(self, servers: List[VLLMServer], tracker: MetricsTracker) -> None:
+        super().__init__(servers)
+        self._tracker = tracker
+
+    @property
+    @abstractmethod
+    def tracker(self) -> MetricsTracker:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def create(
+        cls, servers: List[VLLMServer], threshold: float
+    ) -> "MetricsBasedStrategy":
+        """
+        Subclasses must implement this async method to handle async setup
+        and return an instance of the strategy.
+        Should create a MetricsTracker instance and pass it to the constructor
+        """

--- a/workers/consumer/strategy/metrics_tracker.py
+++ b/workers/consumer/strategy/metrics_tracker.py
@@ -1,0 +1,124 @@
+import asyncio
+import logging
+from typing import Dict, List
+
+import aiohttp
+
+from .histogram import Histogram
+
+
+class MetricsTracker:
+    # We can imagine different strategies based on different metrics
+    # In this case, these patterns would be passed in the constructor
+    e2e_latency_pattern = r"^vllm:e2e_request_latency_seconds_bucket.*$"
+    time_to_first_token_pattern = r"^vllm:time_to_first_token_seconds_bucket.*$"
+
+    def __init__(self, urls: List[str]) -> None:
+        self.urls = urls
+        # The whole monitoring process only cares about urls, not complete server object,
+        # which are less handy to use as dictionnary keys (i.e to hash)
+        self.e2e_latency_last_histograms: Dict[str, Histogram] = {
+            url: Histogram() for url in self.urls
+        }
+        self.e2e_latency_diff_histograms: Dict[str, Histogram] = {
+            url: Histogram() for url in self.urls
+        }
+        self.time_to_first_token_last_histograms: Dict[str, Histogram] = {
+            url: Histogram() for url in self.urls
+        }
+        self.time_to_first_token_diff_histograms: Dict[str, Histogram] = {
+            url: Histogram() for url in self.urls
+        }
+        self.monitoring = False
+        self._monitor_tasks = []
+
+    @staticmethod
+    async def fetch_metrics(session: aiohttp.ClientSession, url: str) -> str:
+        async with session.get(f"{url}/metrics") as response:
+            response.raise_for_status()
+            return await response.text()
+
+    @staticmethod
+    def update_histogram(
+        new_histogram: Histogram, last_histogram: Histogram, diff_histogram: Histogram
+    ):
+        new_diff_histogram = Histogram()
+        new_diff_histogram = new_histogram - last_histogram
+
+        last_histogram.update(new_histogram)
+        diff_histogram.update(new_diff_histogram)
+
+    async def update_all_metrics_for_server(
+        self, session: aiohttp.ClientSession, url: str
+    ) -> None:
+        """Fetch metrics once and update histograms for different patterns."""
+        content = await MetricsTracker.fetch_metrics(session, url)
+        if not content:
+            return
+
+        # Process histograms for different patterns
+        for pattern, last_histograms, diff_histograms in [
+            (
+                MetricsTracker.e2e_latency_pattern,
+                self.e2e_latency_last_histograms,
+                self.e2e_latency_diff_histograms,
+            ),
+            (
+                MetricsTracker.time_to_first_token_pattern,
+                self.time_to_first_token_last_histograms,
+                self.time_to_first_token_diff_histograms,
+            ),
+        ]:
+            new_histogram = Histogram.parse(content, pattern)
+            MetricsTracker.update_histogram(
+                new_histogram,
+                last_histograms.setdefault(url, Histogram()),
+                diff_histograms.setdefault(url, Histogram()),
+            )
+
+    async def _monitor_server(self, url: str, interval: int) -> None:
+        async with aiohttp.ClientSession() as session:
+            while self.monitoring:
+                try:
+                    await self.update_all_metrics_for_server(session, url)
+                    logging.debug("Metrics updated for %s", url)
+                    logging.debug(
+                        "e2e latency histogram: %s",
+                        self.e2e_latency_diff_histograms[url],
+                    )
+                    logging.debug(
+                        "time-to-first-token histogram: %s",
+                        self.time_to_first_token_diff_histograms[url],
+                    )
+                    await asyncio.sleep(interval)
+                except asyncio.CancelledError:
+                    logging.debug("Monitoring task cancelled for %s", url)
+                    break
+                # Since we only wait for one server to start consuming (cf metrics.py),
+                # it is possible that some servers are not (yet) reachable,
+                # which leads to aiohttp.ClientConnectorError
+                except aiohttp.ClientConnectorError:
+                    continue
+
+    async def monitor(self, interval: int = 10) -> None:
+        if self.monitoring:
+            logging.debug("Monitoring is already running.")
+            return
+
+        self.monitoring = True
+        self._monitor_tasks = [
+            asyncio.create_task(self._monitor_server(url, interval))
+            for url in self.urls
+        ]
+        logging.debug("Started monitoring for %s servers", len(self.urls))
+
+    async def stop_monitor(self) -> None:
+        if not self.monitoring:
+            logging.debug("Monitoring is not running.")
+            return
+
+        self.monitoring = False
+        for task in self._monitor_tasks:
+            task.cancel()
+        await asyncio.gather(*self._monitor_tasks, return_exceptions=True)
+        logging.debug("Monitoring stopped for all servers.")

--- a/workers/consumer/strategy/metrics_tracker.py
+++ b/workers/consumer/strategy/metrics_tracker.py
@@ -49,7 +49,9 @@ class MetricsTracker:
         if not content:
             return
 
-        new_histogram = Histogram.parse(content, MetricsTracker.time_to_first_token_pattern)
+        new_histogram = Histogram.parse(
+            content, MetricsTracker.time_to_first_token_pattern
+        )
         MetricsTracker.update_histogram(
             new_histogram,
             self.time_to_first_token_last_histograms.setdefault(url, Histogram()),

--- a/workers/consumer/strategy/round_robin.py
+++ b/workers/consumer/strategy/round_robin.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from ..vllm_server import VLLMServer
+from .server_selection_strategy import ServerSelectionStrategy
+
+
+class RoundRobin(ServerSelectionStrategy):
+
+    def __init__(self, servers: List[VLLMServer]) -> None:
+        super().__init__(servers)
+        self.round_robin_idx = 0
+
+    def choose_server(self) -> VLLMServer:
+        choice = self.servers[self.round_robin_idx]
+        self.round_robin_idx = (self.round_robin_idx + 1) % len(self.servers)
+        return choice

--- a/workers/consumer/strategy/round_robin.py
+++ b/workers/consumer/strategy/round_robin.py
@@ -4,7 +4,7 @@ from ..vllm_server import VLLMServer
 from .server_selection_strategy import ServerSelectionStrategy
 
 
-class RoundRobin(ServerSelectionStrategy):
+class RoundRobin(ServerSelectionStrategy):  # pylint: disable=too-few-public-methods
 
     def __init__(self, servers: List[VLLMServer]) -> None:
         super().__init__(servers)

--- a/workers/consumer/strategy/server_selection_strategy.py
+++ b/workers/consumer/strategy/server_selection_strategy.py
@@ -15,3 +15,9 @@ class ServerSelectionStrategy(ABC):
     @abstractmethod
     def choose_server(self) -> VLLMServer:
         pass
+
+    async def monitor(self, interval: int = 10) -> None:
+        pass
+
+    async def stop_monitor(self) -> None:
+        pass

--- a/workers/consumer/strategy/server_selection_strategy.py
+++ b/workers/consumer/strategy/server_selection_strategy.py
@@ -4,7 +4,7 @@ from typing import List
 from ..vllm_server import VLLMServer
 
 
-class ServerSelectionStrategy(ABC):
+class ServerSelectionStrategy(ABC): # pylint: disable=too-few-public-methods
     """
     Abstract base class for server selection strategies.
     """
@@ -14,10 +14,4 @@ class ServerSelectionStrategy(ABC):
 
     @abstractmethod
     def choose_server(self) -> VLLMServer:
-        pass
-
-    async def monitor(self, interval: int = 10) -> None:
-        pass
-
-    async def stop_monitor(self) -> None:
         pass

--- a/workers/consumer/strategy/server_selection_strategy.py
+++ b/workers/consumer/strategy/server_selection_strategy.py
@@ -4,7 +4,7 @@ from typing import List
 from ..vllm_server import VLLMServer
 
 
-class ServerSelectionStrategy(ABC): # pylint: disable=too-few-public-methods
+class ServerSelectionStrategy(ABC):  # pylint: disable=too-few-public-methods
     """
     Abstract base class for server selection strategies.
     """

--- a/workers/consumer/strategy/server_selection_strategy.py
+++ b/workers/consumer/strategy/server_selection_strategy.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from ..vllm_server import VLLMServer
+
+
+class ServerSelectionStrategy(ABC):
+    """
+    Abstract base class for server selection strategies.
+    """
+
+    def __init__(self, servers: List[VLLMServer]) -> None:
+        self.servers = servers
+
+    @abstractmethod
+    def choose_server(self) -> VLLMServer:
+        pass

--- a/workers/sender/main.py
+++ b/workers/sender/main.py
@@ -165,6 +165,15 @@ async def proxy(request: Request, call_next):
     llm_url = llm_params["llmUrl"]
     llm_token = llm_params["llmToken"]
 
+    if llm_url == "None":
+        return JSONResponse(
+            content={
+                "object": "error",
+                "error": f"{requested_model} is busy, try again later",
+            },
+            status_code=503,
+        )
+
     headers = {}
     if llm_token:
         headers["Authorization"] = f"Bearer {llm_token}"

--- a/workers/sender/main.py
+++ b/workers/sender/main.py
@@ -166,13 +166,14 @@ async def proxy(request: Request, call_next):
     llm_token = llm_params["llmToken"]
 
     if llm_url == "None":
-        return JSONResponse(
-            content={
-                "object": "error",
-                "error": f"{requested_model} is busy, try again later",
-            },
-            status_code=503,
-        )
+        response_content = {
+            "error": f"{requested_model} is busy, try again later",
+        }
+        match client_type:
+            case "chat":
+                return JSONResponse(content=response_content, status_code=200)
+            case _:
+                return JSONResponse(content=response_content, status_code=503)
 
     headers = {}
     if llm_token:


### PR DESCRIPTION
### Puisque `vllm:avg_generation_throughput_toks_per_s` a été retiré à partir de vllm v0.7

- le consumer maintient maintenant pour chaque instance vllm:
1) le dernier nb total de tokens
2) le dernier timestamp correspondant
3) un flag first time (la première fois qu'on regarde les metrics on a pas de timestamp de référence -> throughput 0)

- à chaque requête sur `/metrics`:
1) on calcule le throughput par Δtokens / Δt
2) on update le nb de tokens et timestamp pour ce serveur 

- `wait_for_vllm` n'utilise plus `update_metrics` mais `ping_server` puisqu'on se fiche des metrics dans ce cas

- pour les versions < 0.7, on continue d'utiliser `vllm:avg_generation_throughput_toks_per_s`

