### PR TITLE
Fix models routes compatibility with OpenAI standard

### DIFF
--- a/workers/sender/main.py
+++ b/workers/sender/main.py
@@ -81,7 +81,7 @@ async def models():
 @app.get("/v1/models/{model_id}")
 async def model(model_id):
     model_data = await get_model_by_id(settings, model_id)
-    if model_data is not None:
+    if model_data is None:
         return JSONResponse(
             content={
                 "object": "error",


### PR DESCRIPTION
Cette PR corrige la route /models vis-à-vis du standard openai et ajoute la prise en charge de la requête d'un modèle en particulier (voir https://platform.openai.com/docs/api-reference/models)