### PR TITLE
Priorité locale

### DIFF
--- a/workers/compose.yml
+++ b/workers/compose.yml
@@ -29,6 +29,10 @@ services:
       DB_USER: user
       DB_PASSWORD: password
       DB_DATABASE: test
+      MODEL_HOST_MAPPING: >
+        {
+          "Qwen/Qwen2-0.5B-Instruct": ["centralesupelec"]
+        }
     restart: on-failure
     depends_on:
       - rabbitmq
@@ -39,13 +43,18 @@ services:
       context: ./consumer
     environment:
       LOG_LEVEL: 10
-      MODEL: Qwen/Qwen2.5-0.5B-Instruct
-      # uncomment next line if you run vllm locally
-      # VLLM_SERVERS: '{"http://host.docker.internal:8000": "secret_key"}'
-      VLLM_SERVERS: '{"http://vllm-arm:8000": "secret_key"}'
+      MODEL: casperhansen/llama-3.3-70b-instruct-awq
+      VLLM_SERVERS: >
+        {
+          "http://host.docker.internal:8000": {
+            "token": "your-token-here",
+            "organization": "centralesupelec"
+          }
+        }
       ROUTING_STRATEGY: least-busy
-      TIME_TO_FIRST_TOKEN_THRESHOLD: 1.0
-      PRIORITY_HANDLER: "vllm"
+      TIME_TO_FIRST_TOKEN_THRESHOLD: 0.5
+      PRIORITY_HANDLER: "ignore"
+      QUALITY_OF_SERVICE_POLICY: "requeue"
     restart: on-failure
     depends_on:
       - rabbitmq
@@ -113,4 +122,4 @@ services:
 
 volumes:
   postgres-data:
-  mysql-data:
+

--- a/workers/consumer/exceptions.py
+++ b/workers/consumer/exceptions.py
@@ -40,3 +40,9 @@ class UnknownQOSPolicy(Exception):
     def __init__(self, passed_policy):
         message = f'"{passed_policy} not recognized; policy must either be "warning-log" or "requeue"'
         super().__init__(message)
+
+
+class UnknownLocalPriorityModel(Exception):
+    def __init__(self, passed_model):
+        message = f'"{passed_model} not recognized; model must either be "private-first" or "private-only"'
+        super().__init__(message)

--- a/workers/consumer/quality_of_service_policy/qos_policy.py
+++ b/workers/consumer/quality_of_service_policy/qos_policy.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
-from aio_pika.abc import AbstractIncomingMessage
+from aio_pika import Exchange
+from aio_pika.abc import AbstractIncomingMessage, AbstractQueue
 
 
 class QualityOfServiceBasePolicy(ABC):  # pylint: disable=too-few-public-methods
@@ -15,7 +16,10 @@ class QualityOfServiceBasePolicy(ABC):  # pylint: disable=too-few-public-methods
     def apply_policy(
         self,
         performance_indicator: float | None,
-        message: AbstractIncomingMessage,
         current_parallel_requests: int,
+        max_parallel_requests: int,
+        message: AbstractIncomingMessage | None = None,
+        target_requeue: AbstractQueue | None = None,
+        exchange: Exchange | None = None,
     ) -> bool:
         pass

--- a/workers/consumer/quality_of_service_policy/requeue_policy.py
+++ b/workers/consumer/quality_of_service_policy/requeue_policy.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
 
-from aio_pika.abc import AbstractIncomingMessage
+from aio_pika import DeliveryMode, Exchange, Message
+from aio_pika.abc import AbstractIncomingMessage, AbstractQueue
 
 from ..settings import settings
 from .qos_policy import QualityOfServiceBasePolicy
@@ -9,19 +10,38 @@ from .qos_policy import QualityOfServiceBasePolicy
 
 class RequeuePolicy(QualityOfServiceBasePolicy):
 
-    async def _delayed_nack(self, msg):
+    async def _delayed_nack(self, msg: AbstractIncomingMessage):
         await asyncio.sleep(settings.METRICS_REFRESH_RATE)
         await msg.nack(requeue=True)
+
+    async def _transfer_message(
+        self, msg: AbstractIncomingMessage, queue: AbstractQueue, exchange: Exchange
+    ):
+        await asyncio.sleep(settings.METRICS_REFRESH_RATE)
+        await exchange.publish(
+            message=Message(
+                body=b"AVAILABLE?",
+                delivery_mode=DeliveryMode.PERSISTENT,
+                correlation_id=msg.correlation_id,
+                reply_to=msg.reply_to,
+                priority=msg.priority,
+            ),
+            routing_key=queue.name,
+        )
+        await msg.ack()
 
     def apply_policy(
         self,
         performance_indicator: float | None,
-        message: AbstractIncomingMessage,
         current_parallel_requests: int,
+        max_parallel_requests: int,
+        message: AbstractIncomingMessage | None = None,
+        target_requeue: AbstractQueue | None = None,
+        exchange: Exchange | None = None,
     ) -> bool:
         if isinstance(performance_indicator, (float, int)) and (
             (performance_indicator > self.performance_threshold)
-            or (current_parallel_requests >= settings.MAX_PARALLEL_REQUESTS)
+            or (current_parallel_requests >= max_parallel_requests)
         ):
             logging.info(
                 "QoS policy deferred the message; requeuing. performance_indicator: %s, self.performance_threshold: %s, current_parallel_requests: %s, max_parallel_requests: %s",
@@ -30,6 +50,11 @@ class RequeuePolicy(QualityOfServiceBasePolicy):
                 current_parallel_requests,
                 settings.MAX_PARALLEL_REQUESTS,
             )
-            asyncio.create_task(self._delayed_nack(message))
+            if target_requeue:
+                asyncio.create_task(
+                    self._transfer_message(message, target_requeue, exchange)
+                )
+            else:
+                asyncio.create_task(self._delayed_nack(message))
             return False
         return True

--- a/workers/consumer/strategy/server_selection_strategy.py
+++ b/workers/consumer/strategy/server_selection_strategy.py
@@ -13,8 +13,11 @@ class ServerSelectionStrategy(ABC):  # pylint: disable=too-few-public-methods
         self.servers = servers
 
     @abstractmethod
-    def choose_server(self) -> (VLLMServer, float | None):
+    def choose_server(self) -> tuple[VLLMServer, float | None]:
         pass
 
     async def update_servers(self, servers: List[VLLMServer]) -> None:
         self.servers = servers
+
+    def get_server_score(self, url: str) -> None | float:
+        return None

--- a/workers/consumer/vllm_server.py
+++ b/workers/consumer/vllm_server.py
@@ -4,4 +4,6 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class VLLMServer:
     url: str
-    token: str
+    token: str | None
+    organization: str
+    max_parallel_requests: int

--- a/workers/sender/models.py
+++ b/workers/sender/models.py
@@ -22,8 +22,11 @@ async def get_models(settings: Settings):
         }
         # We need to filter out the default entries of the default exchange
         for binding in response.json()
-        if (not binding["destination"].startswith("amq"))
-        and (not binding["destination"].endswith("completed"))
+        if (
+            not binding["destination"].startswith("amq")
+            and not binding["destination"].endswith("completed")
+            and not binding["destination"].endswith("private")
+        )
     ]
 
     return models


### PR DESCRIPTION
### Changes

- Les objets `VLLMServer` ont maintenant un attribut `organization`.
- Les consumers s'en servent pour déclarer une queue par paire modèle/organisation. (nom: `f"{model}_{organization}"`)

### Flow

- Le sender reçoit la requête, qui contient: le modèle demandé, le token et le `local_priority_model` (any (par défaut), private-first ou private-only)
- Du token est déduit l'organisation.
- Si any -> comportement inchangé (message poussé en queue commune par modèle)
- Sinon, on pousse dans la queue modèle/organisation, avec en corps de message le `local_priority_model`et l'`organization`.
- Le consumer le dépile, et déduit de ces 2 informations:
- - Le serveur cible
- - Le comportement de requeuing à adopter  si ce serveur n'est pas en bonnes conditions