### PR TITLE
ajouter DO_NOT_UPDATE_CA pour le lancement des conteneurs non root

### DIFF
--- a/consumer-entrypoint.sh
+++ b/consumer-entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 
-update-ca-certificates
+if [ -z "$DO_NOT_UPDATE_CA" ]; then
+    update-ca-certificates
+fi
 
 # print and run image cmd
 echo "$@"

--- a/sender-entrypoint.sh
+++ b/sender-entrypoint.sh
@@ -4,7 +4,9 @@ set -e
 # run migrations
 alembic upgrade head
 
-update-ca-certificates
+if [ -z "$DO_NOT_UPDATE_CA" ]; then
+    update-ca-certificates
+fi
 
 # print and run image cmd
 echo "$@"


### PR DESCRIPTION
Bonjour,
Afin de pouvoir faire fonctionner l'image en tant qu'user non root serait-il possible de desactiver l'update de CA si un flag est fourni ?
Cordialement
Antoine REGNIER